### PR TITLE
Point the Lite download at the current blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo allows to obtain data needed to run IP Intelligence examples:
 
 ### From Azure
 Either get it from the URL: 
-https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-LiteIpiV41.ipi.gz
+https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz
 
 or run a script to download files from Azure.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ## Introduction
 
 This repo allows to obtain data needed to run IP Intelligence examples:
-- a URL and script to download 'Lite' IP Intelligence data file
 - evidence files with lists of random IP addresses needed for some examples
 - scripts to generate lists of random IP addresses like the above
 - scripts to download 'Lite' IP Intelligence data file
@@ -11,11 +10,7 @@ This repo allows to obtain data needed to run IP Intelligence examples:
 
 ## Download Lite data file
 
-### From Azure
-Either get it from the URL: 
-https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz
-
-or run a script to download files from Azure.
+Run one of the scripts in this repository to download and unpack the file:
 
 | Script | Language | OS |
 | -- | -- | -- |

--- a/README.md
+++ b/README.md
@@ -10,12 +10,29 @@ This repo allows to obtain data needed to run IP Intelligence examples:
 
 ## Download Lite data file
 
-Run one of the scripts in this repository to download and unpack the file:
+The Lite data file is too large to commit to this repository, so one of the
+scripts below downloads it from 51Degrees storage instead:
 
 | Script | Language | OS |
 | -- | -- | -- |
 | `./get-lite-file-from-azure.ps1` | PowerShell | [Windows](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5), [Linux](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.5), [macOS](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.5) |
 | `./get-lite-file-from-azure.sh` | Shell | Linux, macOS |
+
+Run the script from this directory, because the examples and tests look for
+the file here:
+
+```pwsh
+cd ip-intelligence-data
+./get-lite-file-from-azure.ps1
+```
+
+The script downloads the archive as `51Degrees-LiteV41.ipi.gz` (about 230 MB),
+prints its MD5 hash and unpacks it to `51Degrees-LiteV41.ipi` (about 460 MB)
+in the directory it is run from. If the archive is already present the
+download is skipped and the existing archive is unpacked again. Pass `-Force`
+(PowerShell) or `-f` (shell) to download a fresh copy, for example when a new
+monthly data file has been published. The shell script needs `curl`, `gunzip`
+and `md5sum` (`md5` on macOS) to be available.
 
 
 ## Files

--- a/get-lite-file-from-azure.ps1
+++ b/get-lite-file-from-azure.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 # Local Vars
-$ArchiveUrl = "https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-LiteIpiV41.ipi.gz"
+$ArchiveUrl = "https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz"
 $ArchiveName = (Join-Path (Get-Location) "51Degrees-LiteV41.ipi.gz")
 $ArchivedName = (Join-Path (Get-Location) "51Degrees-LiteV41.ipi")
 

--- a/get-lite-file-from-azure.sh
+++ b/get-lite-file-from-azure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Local vars
-ARCHIVE_URL="https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-LiteIpiV41.ipi.gz"
+ARCHIVE_URL="https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz"
 ARCHIVE_NAME="51Degrees-LiteV41.ipi.gz"
 ARCHIVED_NAME="51Degrees-LiteV41.ipi"
 


### PR DESCRIPTION
Closes #28. Addresses the distribution part of #30.

## Problem

The Lite download URL in the README and both `get-lite-file-from-azure` scripts points at `enterpriseipi/51Degrees-LiteIpiV41.ipi.gz`. That blob was last modified on 8 April 2026 (MD5 of the served archive `E3F5EC950A77A69669C03F4FE0AC4D37`) and serves a data format 4.4 file that current engines reject, including `com.51degrees:ip-intelligence:4.5.41`, with "The data is an unsupported version". Anyone following the README gets a Lite file that no published engine can load.

## Fix

Current monthly builds are published to the same container under the production file naming, `enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz` (last modified 2 June 2026, data format 4.5). This PR points both download scripts at that blob, as requested in #28. The README no longer advertises a direct URL at all, since raw blob links have gone stale before, it now directs users to the scripts in this repository as the supported way to obtain the file, and documents how to run them. The unpacked local filename (`51Degrees-LiteV41.ipi`) is unchanged, so nothing that consumes the file needs to change.

## Verification

- The new blob is byte-identical to the June 2026 production build on the internal production store (MD5 `C6F414FB7ED0A8A0C82C8B6971321349` for both).
- The unpacked file loads and processes evidence with `ip-intelligence` 4.5.41. The two ip-intelligence-java-examples tests that depend on the Lite-only RegisteredName property (OfflineProcessing and PerformanceBenchmark) pass against it.

## Consideration for the data owners

Per #28 the stale `51Degrees-LiteIpiV41.ipi.gz` blob is retained until this change lands and should be removed afterwards, so stale links elsewhere fail loudly rather than serving an unloadable file. The going-forward format alignment request in #30 (free files tracking the Enterprise data format) remains with the data owners.