### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=home&utm_campaign=c-open-source "Data rewards the curious") **IP Intelligence Data Files**
+# ![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-data&utm_content=readme.md&utm_term=ip-intelligence-data-files "Data rewards the curious") **IP Intelligence Data Files**
 
 ## Introduction
 
@@ -34,7 +34,7 @@ The [properties](https://51degrees.me/developers/property-dictionary?item=Asn%7C
 - Asn
 - AsnName
 
-More properties are available as part of the Enterprise data file - [contact us](https://51degrees.com/contact-us).
+More properties are available as part of the Enterprise data file - [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-data&utm_content=readme.md&utm_term=51degrees-ipiv4asnipiv41-ipi).
 
 This file is updated monthly.
 
@@ -48,7 +48,7 @@ The properties available in this file are:
 - RegisteredName
 - RegisteredOwner
 
-More properties are available as part of the Enterprise data file - [contact us](https://51degrees.com/contact-us).
+More properties are available as part of the Enterprise data file - [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-data&utm_content=readme.md&utm_term=51degrees-litev41-ipi).
 
 This 'lite' file is built from a subsection of all IPs and is updated less frequently than the Enterprise IPI data file.
 


### PR DESCRIPTION
Add UTM parameters to navigational 51degrees.com links so the Content Team can trace traffic to its exact source.

- README.md: replaced the legacy Logo.ashx logo URL with the img/logo.png scheme, tagged the two 51degrees.com/contact-us links (one per data-file section, each with a section-specific term).

Adds the UTM link lint workflow in a separate commit.

Left untouched: the Azure blob data-download URL (functional endpoint) and the 51degrees.me property-dictionary link (different domain, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)